### PR TITLE
Adjustment of low altitude camera reversion constants.

### DIFF
--- a/CameraTools/CTPersistantFIeld.cs
+++ b/CameraTools/CTPersistantFIeld.cs
@@ -7,20 +7,17 @@ namespace CameraTools
 	{
 		public static string settingsURL = "GameData/CameraTools/settings.cfg";
 
-		public CTPersistantField()
-		{
-
-		}
+		public CTPersistantField() { }
 
 		public static void Save()
 		{
 			ConfigNode fileNode = ConfigNode.Load(settingsURL);
 			ConfigNode settings = fileNode.GetNode("CToolsSettings");
 
-
-			foreach(var field in typeof(CamTools).GetFields())
+			foreach (var field in typeof(CamTools).GetFields())
 			{
-				if(!field.IsDefined(typeof(CTPersistantField), false)) continue;
+				if (field == null) continue;
+				if (!field.IsDefined(typeof(CTPersistantField), false)) continue;
 
 				settings.SetValue(field.Name, field.GetValue(CamTools.fetch).ToString(), true);
 			}
@@ -33,14 +30,15 @@ namespace CameraTools
 			ConfigNode fileNode = ConfigNode.Load(settingsURL);
 			ConfigNode settings = fileNode.GetNode("CToolsSettings");
 
-			foreach(var field in typeof(CamTools).GetFields())
+			foreach (var field in typeof(CamTools).GetFields())
 			{
-				if(!field.IsDefined(typeof(CTPersistantField), false)) continue;
+				if (field == null) continue;
+				if (!field.IsDefined(typeof(CTPersistantField), false)) continue;
 
-				if(settings.HasValue(field.Name))
+				if (settings.HasValue(field.Name))
 				{
 					object parsedValue = ParseValue(field.FieldType, settings.GetValue(field.Name));
-					if(parsedValue != null)
+					if (parsedValue != null)
 					{
 						field.SetValue(CamTools.fetch, parsedValue);
 					}
@@ -50,30 +48,30 @@ namespace CameraTools
 
 		public static object ParseValue(Type type, string value)
 		{
-			if(type == typeof(string))
+			if (type == typeof(string))
 			{
 				return value;
 			}
 
-			if(type == typeof(bool))
+			if (type == typeof(bool))
 			{
 				return bool.Parse(value);
 			}
-			else if(type.IsEnum)
+			else if (type.IsEnum)
 			{
 				return Enum.Parse(type, value);
 			}
-			else if(type == typeof(float))
+			else if (type == typeof(float))
 			{
 				return float.Parse(value);
 			}
-			else if(type == typeof(Single))
+			else if (type == typeof(Single))
 			{
 				return Single.Parse(value);
 			}
 
 
-			UnityEngine.Debug.LogError("CameraTools failed to parse settings field of type "+type.ToString()+" and value "+value);
+			UnityEngine.Debug.LogError("CameraTools failed to parse settings field of type " + type.ToString() + " and value " + value);
 
 			return null;
 		}

--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -1169,43 +1169,52 @@ namespace CameraTools
 			Debug.Log("flightCamera position post init: " + flightCamera.transform.position);
 		}
 
-		void RevertCamera()
+		public void RevertCamera()
 		{
-			posCounter = 0;
-
-			if (cameraToolActive)
+			try
 			{
-				presetOffset = flightCamera.transform.position;
-				if (camTarget == null)
+				posCounter = 0;
+
+				if (cameraToolActive)
 				{
-					savedRotation = flightCamera.transform.rotation;
-					hasSavedRotation = true;
+					presetOffset = flightCamera.transform.position;
+					if (camTarget == null)
+					{
+						savedRotation = flightCamera.transform.rotation;
+						hasSavedRotation = true;
+					}
+					else
+					{
+						hasSavedRotation = false;
+					}
 				}
-				else
+				hasDied = false;
+				if (FlightGlobals.ActiveVessel != null && HighLogic.LoadedScene == GameScenes.FLIGHT)
 				{
-					hasSavedRotation = false;
+					flightCamera.SetTarget(FlightGlobals.ActiveVessel.transform, FlightCamera.TargetMode.Vessel);
 				}
+				flightCamera.transform.parent = origParent;
+				flightCamera.transform.position = origPosition;
+				flightCamera.transform.rotation = origRotation;
+				Camera.main.nearClipPlane = origNearClip;
+
+				flightCamera.SetFoV(60);
+				flightCamera.ActivateUpdate();
+				currentFOV = 60;
+
+				cameraToolActive = false;
+
+
+				StopPlayingPath();
+
+				ResetDoppler();
 			}
-			hasDied = false;
-			if (FlightGlobals.ActiveVessel != null && HighLogic.LoadedScene == GameScenes.FLIGHT)
+			catch
 			{
-				flightCamera.SetTarget(FlightGlobals.ActiveVessel.transform, FlightCamera.TargetMode.Vessel);
+				Debug.LogError("DEBUG flightCamera " + flightCamera);
+				Debug.LogError("DEBUG FlightGlobals.ActiveVessel " + FlightGlobals.ActiveVessel);
+				throw;
 			}
-			flightCamera.transform.parent = origParent;
-			flightCamera.transform.position = origPosition;
-			flightCamera.transform.rotation = origRotation;
-			Camera.main.nearClipPlane = origNearClip;
-
-			flightCamera.SetFoV(60);
-			flightCamera.ActivateUpdate();
-			currentFOV = 60;
-
-			cameraToolActive = false;
-
-
-			StopPlayingPath();
-
-			ResetDoppler();
 
 			try
 			{
@@ -2226,10 +2235,10 @@ namespace CameraTools
 				}
 				if (randomMode)
 				{
-					var lowAlt = 100.0;
+					var lowAlt = 50.0; // With the new terrain avoidance, being lower than 50m is better than 100m for being interesting.
 					if (vessel.verticalSpeed < -20)
 					{
-						lowAlt = vessel.verticalSpeed * -5;
+						lowAlt = vessel.verticalSpeed * -3; // 3s is plenty
 					}
 					if (vessel != null && vessel.radarAltitude < lowAlt)
 					{

--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -21,8 +21,7 @@ namespace CameraTools
 
 		Part camTarget = null;
 
-		[CTPersistantField]
-		public ReferenceModes referenceMode = ReferenceModes.Surface;
+		[CTPersistantField] public ReferenceModes referenceMode = ReferenceModes.Surface;
 		Vector3 cameraUp = Vector3.up;
 
 		string fmUpKey = "[7]";
@@ -50,11 +49,9 @@ namespace CameraTools
 		float leftIndent = 12;
 		float entryHeight = 20;
 
-		[CTPersistantField]
-		public ToolModes toolMode = ToolModes.StationaryCamera;
+		[CTPersistantField] public ToolModes toolMode = ToolModes.StationaryCamera;
 
-		[CTPersistantField]
-		public bool randomMode = false;
+		[CTPersistantField] public bool randomMode = false;
 
 		bool temporaryRevert = false;
 
@@ -64,39 +61,28 @@ namespace CameraTools
 		float incrButtonWidth = 26;
 
 		//stationary camera vars
-		[CTPersistantField]
-		public bool autoFlybyPosition = false;
-		[CTPersistantField]
-		public bool autoFOV = false;
+		[CTPersistantField] public bool autoFlybyPosition = false;
+		[CTPersistantField] public bool autoFOV = false;
 		float manualFOV = 60;
 		float currentFOV = 60;
 		Vector3 manualPosition = Vector3.zero;
-		[CTPersistantField]
-		public float freeMoveSpeed = 10;
+		[CTPersistantField] public float freeMoveSpeed = 10;
 		string guiFreeMoveSpeed = "10";
-		[CTPersistantField]
-		public float keyZoomSpeed = 1;
+		[CTPersistantField] public float keyZoomSpeed = 1;
 		string guiKeyZoomSpeed = "1";
 		float zoomFactor = 1;
-		[CTPersistantField]
-		public float zoomExp = 1;
-		[CTPersistantField]
-		public bool enableKeypad = false;
-		[CTPersistantField]
-		public float maxRelV = 2500;
+		[CTPersistantField] public float zoomExp = 1;
+		[CTPersistantField] public bool enableKeypad = false;
+		[CTPersistantField] public float maxRelV = 2500;
 
 		bool setPresetOffset = false;
 		Vector3 presetOffset = Vector3.zero;
 		bool hasSavedRotation = false;
 		Quaternion savedRotation;
-		[CTPersistantField]
-		public bool manualOffset = false;
-		[CTPersistantField]
-		public float manualOffsetForward = 500;
-		[CTPersistantField]
-		public float manualOffsetRight = 50;
-		[CTPersistantField]
-		public float manualOffsetUp = 5;
+		[CTPersistantField] public bool manualOffset = false;
+		[CTPersistantField] public float manualOffsetForward = 500;
+		[CTPersistantField] public float manualOffsetRight = 50;
+		[CTPersistantField] public float manualOffsetUp = 5;
 		string guiOffsetForward = "500";
 		string guiOffsetRight = "50";
 		string guiOffsetUp = "5";
@@ -105,11 +91,9 @@ namespace CameraTools
 		Vector3 lastTargetPosition = Vector3.zero;
 		bool hasTarget = false;
 
-		[CTPersistantField]
-		public bool useOrbital = false;
+		[CTPersistantField] public bool useOrbital = false;
 
-		[CTPersistantField]
-		public bool targetCoM = false;
+		[CTPersistantField] public bool targetCoM = false;
 
 		bool hasDied = false;
 		float diedTime = 0;
@@ -131,10 +115,8 @@ namespace CameraTools
 		bool mouseUp = false;
 
 		//Keys
-		[CTPersistantField]
-		public string cameraKey = "home";
-		[CTPersistantField]
-		public string revertKey = "end";
+		[CTPersistantField] public string cameraKey = "home";
+		[CTPersistantField] public string revertKey = "end";
 
 		//recording input for key binding
 		bool isRecordingInput = false;
@@ -150,14 +132,12 @@ namespace CameraTools
 		float[] originalAudioSourceDoppler;
 		bool hasSetDoppler = false;
 
-		[CTPersistantField]
-		public bool useAudioEffects = true;
+		[CTPersistantField] public bool useAudioEffects = true;
 
 		//camera shake
 		Vector3 shakeOffset = Vector3.zero;
 		float shakeMagnitude = 0;
-		[CTPersistantField]
-		public float shakeMultiplier = 1;
+		[CTPersistantField] public float shakeMultiplier = 1;
 
 		public delegate void ResetCTools();
 		public static event ResetCTools OnResetCTools;
@@ -166,16 +146,12 @@ namespace CameraTools
 		//dogfight cam
 		Vessel dogfightPrevTarget;
 		Vessel dogfightTarget;
-		[CTPersistantField]
-		float dogfightDistance = 30;
-		[CTPersistantField]
-		float dogfightOffsetX = 10;
-		[CTPersistantField]
-		float dogfightOffsetY = 4;
+		[CTPersistantField] public float dogfightDistance = 30;
+		[CTPersistantField] public float dogfightOffsetX = 10;
+		[CTPersistantField] public float dogfightOffsetY = 4;
 		float dogfightMaxOffset = 50;
 		float dogfightLerp = 20;
-		[CTPersistantField]
-		float autoZoomMargin = 20;
+		[CTPersistantField] public float autoZoomMargin = 20;
 		List<Vessel> loadedVessels;
 		bool showingVesselList = false;
 		bool dogfightLastTarget = false;
@@ -185,8 +161,7 @@ namespace CameraTools
 		//bdarmory
 		bool hasBDAI = false;
 		bool hasBDWM = false;
-		[CTPersistantField]
-		public bool useBDAutoTarget = false;
+		[CTPersistantField] public bool useBDAutoTarget = false;
 		object aiComponent = null;
 		object wmComponent = null;
 		FieldInfo bdAiTargetField;
@@ -1352,7 +1327,7 @@ namespace CameraTools
 			{
 				GUI.Label(new Rect(leftIndent, contentTop + (line * entryHeight), contentWidth / 2, entryHeight), "Autozoom Margin: ");
 				line++;
-				autoZoomMargin = GUI.HorizontalSlider(new Rect(leftIndent, contentTop + ((line) * entryHeight), contentWidth - 45, entryHeight), autoZoomMargin, 0, 50);
+				autoZoomMargin = (int)(GUI.HorizontalSlider(new Rect(leftIndent, contentTop + ((line) * entryHeight), contentWidth - 45, entryHeight), autoZoomMargin, 0, 50) * 2) / 2f;
 				GUI.Label(new Rect(leftIndent + contentWidth - 40, contentTop + ((line - 0.15f) * entryHeight), 40, entryHeight), autoZoomMargin.ToString("0.0"), leftLabel);
 			}
 			else
@@ -1561,17 +1536,17 @@ namespace CameraTools
 				line++;
 				GUI.Label(new Rect(leftIndent, contentTop + (line * entryHeight), contentWidth / 2, entryHeight), "Distance: " + dogfightDistance.ToString("0.0"));
 				line++;
-				dogfightDistance = GUI.HorizontalSlider(new Rect(leftIndent, contentTop + (line * entryHeight), contentWidth, entryHeight), dogfightDistance, 1, 100);
+				dogfightDistance = (int)(GUI.HorizontalSlider(new Rect(leftIndent, contentTop + (line * entryHeight), contentWidth, entryHeight), dogfightDistance, 1, 100) * 2) / 2f;
 				line += 1.5f;
 
 				GUI.Label(new Rect(leftIndent, contentTop + (line * entryHeight), contentWidth, entryHeight), "Offset:");
 				line++;
 				GUI.Label(new Rect(leftIndent, contentTop + (line * entryHeight), 15, entryHeight), "X: ");
-				dogfightOffsetX = GUI.HorizontalSlider(new Rect(leftIndent + 15, contentTop + (line * entryHeight) + 6, contentWidth - 45, entryHeight), dogfightOffsetX, -dogfightMaxOffset, dogfightMaxOffset);
+				dogfightOffsetX = (int)(GUI.HorizontalSlider(new Rect(leftIndent + 15, contentTop + (line * entryHeight) + 6, contentWidth - 45, entryHeight), dogfightOffsetX, -dogfightMaxOffset, dogfightMaxOffset) * 2) / 2f;
 				GUI.Label(new Rect(leftIndent + contentWidth - 25, contentTop + (line * entryHeight), 25, entryHeight), dogfightOffsetX.ToString("0.0"));
 				line++;
 				GUI.Label(new Rect(leftIndent, contentTop + (line * entryHeight), 15, entryHeight), "Y: ");
-				dogfightOffsetY = GUI.HorizontalSlider(new Rect(leftIndent + 15, contentTop + (line * entryHeight) + 6, contentWidth - 45, entryHeight), dogfightOffsetY, -dogfightMaxOffset, dogfightMaxOffset);
+				dogfightOffsetY = (int)(GUI.HorizontalSlider(new Rect(leftIndent + 15, contentTop + (line * entryHeight) + 6, contentWidth - 45, entryHeight), dogfightOffsetY, -dogfightMaxOffset, dogfightMaxOffset) * 2) / 2f;
 				GUI.Label(new Rect(leftIndent + contentWidth - 25, contentTop + (line * entryHeight), 25, entryHeight), dogfightOffsetY.ToString("0.0"));
 				line += 1.5f;
 			}
@@ -1928,6 +1903,7 @@ namespace CameraTools
 		void DisableGui()
 		{
 			guiEnabled = false;
+			Save();
 			Debug.Log("Hiding CamTools GUI");
 		}
 


### PR DESCRIPTION
Tweak the conditions for reverting camera (to Pathing) due to low altitude as the better terrain avoidance causes this situation more often, especially for slow WW1 planes.
Also, some changes due to auto-formatting.